### PR TITLE
EuiColorPaletteDisplay TypeScript assist

### DIFF
--- a/src/components/color_picker/color_palette_display/__snapshots__/color_palette_display.test.tsx.snap
+++ b/src/components/color_picker/color_palette_display/__snapshots__/color_palette_display.test.tsx.snap
@@ -28,6 +28,36 @@ exports[`EuiColorPaletteDisplay is rendered 1`] = `
 </span>
 `;
 
+exports[`EuiColorPaletteDisplay props HTML attributes accepts span attributes 1`] = `
+<span
+  aria-label="aria-label"
+  class="euiColorPaletteDisplay testClass1 testClass2 euiColorPaletteDisplay--sizeSmall"
+  data-test-subj="test subject string"
+  id="id"
+  title="title"
+>
+  <span
+    class="euiColorPaletteDisplayFixed__bleedArea"
+  >
+    <span
+      style="background-color:#1fb0b2;width:20%"
+    />
+    <span
+      style="background-color:#ffdb6d;width:20%"
+    />
+    <span
+      style="background-color:#ee9191;width:20%"
+    />
+    <span
+      style="background-color:#ffffff;width:20%"
+    />
+    <span
+      style="background-color:#888094;width:20%"
+    />
+  </span>
+</span>
+`;
+
 exports[`EuiColorPaletteDisplay props size m is rendered 1`] = `
 <span
   aria-label="aria-label"

--- a/src/components/color_picker/color_palette_display/color_palette_display.test.tsx
+++ b/src/components/color_picker/color_palette_display/color_palette_display.test.tsx
@@ -119,5 +119,21 @@ describe('EuiColorPaletteDisplay', () => {
         });
       });
     });
+
+    describe('HTML attributes', () => {
+      it('accepts span attributes', () => {
+        const component = render(
+          <EuiColorPaletteDisplay
+            {...requiredProps}
+            palette={palette}
+            type="fixed"
+            id="id"
+            title="title"
+          />
+        );
+
+        expect(component).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/components/color_picker/color_palette_display/color_palette_display.tsx
+++ b/src/components/color_picker/color_palette_display/color_palette_display.tsx
@@ -19,10 +19,16 @@
 
 import React, { FunctionComponent } from 'react';
 import classnames from 'classnames';
-import { CommonProps, keysOf } from '../../common';
+import { ExclusiveUnion, keysOf } from '../../common';
 import { ColorStop } from '../color_stops';
-import { EuiColorPaletteDisplayFixed } from './color_palette_display_fixed';
-import { EuiColorPaletteDisplayGradient } from './color_palette_display_gradient';
+import {
+  EuiColorPaletteDisplayFixed,
+  EuiColorPaletteDisplayFixedProps,
+} from './color_palette_display_fixed';
+import {
+  EuiColorPaletteDisplayGradient,
+  EuiColorPaletteDisplayGradientProps,
+} from './color_palette_display_gradient';
 
 const sizeToClassNameMap = {
   xs: 'euiColorPaletteDisplay--sizeExtraSmall',
@@ -34,17 +40,34 @@ export const SIZES = keysOf(sizeToClassNameMap);
 
 export type EuiColorPaletteDisplaySize = keyof typeof sizeToClassNameMap;
 
-export type EuiColorPaletteDisplayProps = CommonProps & {
-  /**
-   *  Specify the type of palette. `gradient`: each color fades into the next. `fixed`: individual color blocks
-   */
-  type?: 'gradient' | 'fixed';
+export interface EuiColorPaletteDisplayShared {
   /**
    * Array of color `strings` or an array of #ColorStop. The stops must be numbers in an ordered range.
    */
   palette: string[] | ColorStop[];
+}
+
+interface DisplayGradient extends EuiColorPaletteDisplayGradientProps {
+  /**
+   *   Specify the type of palette.
+   *  `gradient`: each color fades into the next.
+   */
+  type: 'gradient';
+}
+
+interface DisplayFixed extends EuiColorPaletteDisplayFixedProps {
+  /**
+   *  `fixed`: individual color blocks.
+   */
+  type?: 'fixed';
+}
+
+export type EuiColorPaletteDisplayProps = {
+  /**
+   * Height of the palette display
+   */
   size?: EuiColorPaletteDisplaySize;
-};
+} & ExclusiveUnion<DisplayFixed, DisplayGradient>;
 
 export const EuiColorPaletteDisplay: FunctionComponent<EuiColorPaletteDisplayProps> = ({
   type = 'fixed',

--- a/src/components/color_picker/color_palette_display/color_palette_display_fixed.tsx
+++ b/src/components/color_picker/color_palette_display/color_palette_display_fixed.tsx
@@ -17,17 +17,15 @@
  * under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
 import { CommonProps } from '../../common';
-import { ColorStop } from '../color_stops';
 import { getFixedLinearGradient } from '../utils';
+import { EuiColorPaletteDisplayShared } from './color_palette_display';
 
-export type EuiColorPaletteDisplayFixedProps = CommonProps & {
-  /**
-   * Array of color `strings` or an array of #ColorStop. The stops must be numbers in an ordered range.
-   */
-  palette: string[] | ColorStop[];
-};
+export interface EuiColorPaletteDisplayFixedProps
+  extends HTMLAttributes<HTMLSpanElement>,
+    CommonProps,
+    EuiColorPaletteDisplayShared {}
 
 interface paletteItem {
   color: string;

--- a/src/components/color_picker/color_palette_display/color_palette_display_gradient.tsx
+++ b/src/components/color_picker/color_palette_display/color_palette_display_gradient.tsx
@@ -17,23 +17,22 @@
  * under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, HTMLAttributes } from 'react';
 import { CommonProps } from '../../common';
 import { getLinearGradient } from '../utils';
-import { ColorStop } from '../color_stops';
+import { EuiColorPaletteDisplayShared } from './color_palette_display';
 
-export type EuiColorPaletteDisplayGradientProps = CommonProps & {
-  /**
-   * Array of color `strings` or an array of #ColorStop. The stops must be numbers in an ordered range.
-   */
-  palette: string[] | ColorStop[];
-};
+export interface EuiColorPaletteDisplayGradientProps
+  extends HTMLAttributes<HTMLSpanElement>,
+    CommonProps,
+    EuiColorPaletteDisplayShared {}
 
 export const EuiColorPaletteDisplayGradient: FunctionComponent<EuiColorPaletteDisplayGradientProps> = ({
   palette,
+  style = {},
   ...rest
 }) => {
   const gradient = getLinearGradient(palette);
 
-  return <span style={{ background: gradient }} {...rest} />;
+  return <span style={{ ...style, background: gradient }} {...rest} />;
 };

--- a/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
+++ b/src/components/color_picker/color_palette_picker/color_palette_picker.tsx
@@ -123,12 +123,18 @@ export const EuiColorPalettePicker: FunctionComponent<EuiColorPalettePickerProps
   selectionDisplay = 'palette',
   ...rest
 }) => {
-  const getPalette = (
-    item:
-      | EuiColorPalettePickerPaletteFixedProps
-      | EuiColorPalettePickerPaletteGradientProps
-  ) => {
-    return <EuiColorPaletteDisplay type={item.type} palette={item.palette} />;
+  const getPalette = ({
+    type,
+    palette,
+  }:
+    | EuiColorPalettePickerPaletteFixedProps
+    | EuiColorPalettePickerPaletteGradientProps) => {
+    // Working around ExclusiveUnion
+    return type === 'gradient' ? (
+      <EuiColorPaletteDisplay type={type} palette={palette} />
+    ) : (
+      <EuiColorPaletteDisplay type={type} palette={palette} />
+    );
   };
 
   const paletteOptions = palettes.map(


### PR DESCRIPTION
Had all the changes locally as I tried to solve type sharing, so a PR for you.

* Add HTMLSpanElement support to both display types
* Share more types
* Make a type distinction between display types in EuiColorPaletteDisplay