### PR TITLE
Change triggerAnimation() to animate()

### DIFF
--- a/src-docs/src/views/header/header_alert.js
+++ b/src-docs/src/views/header/header_alert.js
@@ -138,10 +138,10 @@ const HeaderUpdates = forwardRef(
     const bellRef = useRef();
     const cheerRef = useRef();
 
-    // we're passing passing the `triggerAnimation` callbacks to the `headerUpdatesRef` child components that we want to animate
+    // we're passing passing the `animate` callbacks to the `headerUpdatesRef` child components that we want to animate
     const animate = useCallback(() => {
-      bellRef.current?.triggerAnimation();
-      cheerRef.current?.triggerAnimation();
+      bellRef.current?.animate();
+      cheerRef.current?.animate();
     }, []);
 
     // we're using the `useImperativeHandle` which allows the child to expose a function to the parent

--- a/src-docs/src/views/header/header_example.js
+++ b/src-docs/src/views/header/header_example.js
@@ -106,7 +106,9 @@ const headerLinksSnippet = `<EuiHeader>
   </EuiHeaderLinks>
 </EuiHeader>`;
 
-const headerAlertSnippet = `<EuiHeader>
+const headerAlertSnippet = [
+  ,
+  `<EuiHeader>
   <EuiHeaderSection grow={false}>
     <EuiHeaderSectionItem>
       <!-- HeaderSectionItem content -->
@@ -117,18 +119,24 @@ const headerAlertSnippet = `<EuiHeader>
     <EuiHeaderSectionItem>
       <!-- Button to trigger portal content like a EuiPopover or a EuiFlyout -->
       <EuiHeaderSectionItemButton
+        ref={bellButtonRef}
         aria-controls={portalContentId}
         aria-expanded={isPortalContentVisible}
         aria-label="Open portal content"
         onClick={() => showPortalConten()}
         notification={showNotification}
-        animation={isAnimating}
       >
         <EuiIcon type="bell" />
       </EuiHeaderSectionItemButton>
     </EuiHeaderSectionItem>
   </EuiHeaderSection>
-</EuiHeader>`;
+</EuiHeader>`,
+  `<!-- You can target the bellButtonRef to trigger the animation -->
+<EuiButton onClick={() => bellButtonRef.current?.animate()}>
+  Animate
+</EuiButton>
+`,
+];
 
 export const HeaderExample = {
   title: 'Header',
@@ -343,9 +351,8 @@ export const HeaderExample = {
             <EuiCode>node</EuiCode> that will render inside a{' '}
             <strong>EuiBadgeNotification</strong> or pass{' '}
             <EuiCode>true</EuiCode> to render a simple dot. You can also animate
-            the button by calling the <EuiCode>triggerAnimation()</EuiCode>{' '}
-            method on the <strong>EuiHeaderSectionItemButton</strong>{' '}
-            <EuiCode>ref</EuiCode>.
+            the button by calling the <EuiCode>animate()</EuiCode> method on the{' '}
+            <strong>EuiHeaderSectionItemButton</strong> <EuiCode>ref</EuiCode>.
           </p>
 
           <p>

--- a/src/components/header/header_section/header_section_item_button.tsx
+++ b/src/components/header/header_section/header_section_item_button.tsx
@@ -74,7 +74,7 @@ export const EuiHeaderSectionItemButton = forwardRef<
       ref,
       () => {
         if (buttonRef) {
-          (buttonRef as any).triggerAnimation = () => {
+          (buttonRef as any).animate = () => {
             const keyframes: Keyframe[] = [
               { transform: 'rotate(0)', offset: 0, easing: 'ease-in-out' },
               {


### PR DESCRIPTION
Hi @chandler,

When we are in a parent component and we trigger the animation we would call `animate()`:

```js
export default () => {
  const headerUpdatesRef = useRef();

  return (
    <>
      <EuiButton size="s" onClick={() => headerUpdatesRef.current?.animate()}>
        Animate
      </EuiButton>
      <EuiSpacer />
      <EuiHeader>
        <EuiHeaderSection grow={false}>
          <EuiHeaderSectionItem border="right">
            <EuiHeaderLogo>Elastic</EuiHeaderLogo>
          </EuiHeaderSectionItem>
        </EuiHeaderSection>
        <EuiHeaderSection side="right">
          <EuiHeaderSectionItem>
            <HeaderUpdates ref={headerUpdatesRef} />
          </EuiHeaderSectionItem>
        </EuiHeaderSection>
      </EuiHeader>
    </>
  );
};
```

Then inside of `<HeaderUpdates />` component, we would call `triggerAnimation()`:

```js
bellRef.current?.triggerAnimation();
```

But if we don't have the `<HeaderUpdates />` component. We would only call `triggerAnimation()`:

```js
export default () => {
  const bellRef = useRef();

  return (
    <>
      <EuiButton size="s" onClick={() => bellRef.current?.triggerAnimation()}>
        Animate
      </EuiButton>
      <EuiSpacer />
      <EuiHeader>
        <EuiHeaderSection grow={false}>
          <EuiHeaderSectionItem border="right">
            <EuiHeaderLogo>Elastic</EuiHeaderLogo>
          </EuiHeaderSectionItem>
        </EuiHeaderSection>
        <EuiHeaderSection side="right">
          <EuiHeaderSectionItem>
            <EuiHeaderSectionItemButton ref={bellRef}>
              <EuiIcon type="bell" />
            </EuiHeaderSectionItemButton>
          </EuiHeaderSectionItem>
        </EuiHeaderSection>
      </EuiHeader>
    </>
  );
};
```

It means that we can call `triggerAnimation()` or `animate()`. I think this for the user is a little bit confusing. So my proposal is to rename the  `triggerAnimation()` to `animate()`.

So no matter which scenario we are in, we always call `animate()` to trigger the animation.

What do you think?
