### PR TITLE
Refactored EuiEventNotification context menu item creation

### DIFF
--- a/src-docs/src/views/notification_events/notification_events.tsx
+++ b/src-docs/src/views/notification_events/notification_events.tsx
@@ -2,10 +2,7 @@ import React, { useState } from 'react';
 import { EuiPanel } from '../../../../src/components/panel';
 import { EuiTitle } from '../../../../src/components/title';
 import { EuiSpacer } from '../../../../src/components/spacer';
-import {
-  EuiContextMenuItem,
-  EuiContextMenuPanelProps,
-} from '../../../../src/components/context_menu';
+import { EuiContextMenuItem } from '../../../../src/components/context_menu';
 import { EuiNotificationEvent } from '../../../../src/components/notification/notification_event';
 
 export default () => {
@@ -85,9 +82,6 @@ export default () => {
   ];
 
   const [events, setEvents] = useState(notificationEventsData);
-  const [contextMenuItems, setContextMenuItems] = useState<
-    EuiContextMenuPanelProps['items']
-  >();
 
   const onRead = (id: string, isRead: boolean) => {
     const nextState = events.map((event) => {
@@ -103,12 +97,17 @@ export default () => {
     setEvents(nextState);
   };
 
-  const onOpenContextMenu = (id: string, isRead: boolean, type: string) => {
-    const nextContextMenus = [
+  const onOpenContextMenu = (id: string) => {
+    const {
+      isRead,
+      meta: { type },
+    } = events.find(({ id: eventId }) => eventId === id)!;
+
+    return [
       <EuiContextMenuItem
         key="contextMenuItemA"
         onClick={() => onRead(id, isRead)}>
-        {isRead ? ' Mark as unread' : 'Mark as read'}
+        {isRead ? 'Mark as unread' : 'Mark as read'}
       </EuiContextMenuItem>,
 
       <EuiContextMenuItem
@@ -121,8 +120,6 @@ export default () => {
         Don’t notify me about this
       </EuiContextMenuItem>,
     ];
-
-    setContextMenuItems(nextContextMenus);
   };
 
   const onClickEventTitle = (id: string) => {
@@ -147,7 +144,6 @@ export default () => {
         primaryAction={event.primaryAction}
         messages={event.messages}
         onRead={onRead}
-        contextMenuItems={contextMenuItems}
         onOpenContextMenu={onOpenContextMenu}
         onClickPrimaryAction={onClickEventPrimaryAction}
         onClickTitle={onClickNoNewsTitles!}

--- a/src/components/notification/notification_event.tsx
+++ b/src/components/notification/notification_event.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, ReactElement } from 'react';
 import classNames from 'classnames';
 import {
   EuiNotificationEventMeta,
@@ -28,8 +28,8 @@ import {
   EuiNotificationEventMessagesProps,
 } from './notification_event_messages';
 import { EuiButtonEmpty, EuiButtonEmptyProps } from '../button';
-import { EuiContextMenuPanelProps } from '../context_menu';
 import { EuiLink } from '../link';
+import { EuiContextMenuItem, EuiContextMenuItemProps } from '../context_menu';
 
 export type EuiNotificationEventPrimaryActionProps = EuiButtonEmptyProps & {
   label: string;
@@ -70,13 +70,11 @@ export type EuiNotificationEventProps = {
    */
   onRead?: (id: string, isRead: boolean) => void;
   /**
-   * An array of context menu items. See #EuiContextMenuItem
+   * Provided the `id` of the event aand must return an array of #EuiContextMenuItem elements
    */
-  contextMenuItems?: EuiContextMenuPanelProps['items'];
-  /**
-   * Returns the `id`, `isRead` ad `type` of the open context menu
-   */
-  onOpenContextMenu?: (id: string, isRead: boolean, type: string) => void;
+  onOpenContextMenu?: (
+    id: string
+  ) => Array<ReactElement<EuiContextMenuItemProps, typeof EuiContextMenuItem>>;
 };
 
 export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> = ({
@@ -87,7 +85,6 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
   primaryAction,
   messages,
   onRead,
-  contextMenuItems,
   onOpenContextMenu,
   onClickTitle,
   onClickPrimaryAction,
@@ -110,11 +107,8 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
         iconAriaLabel={meta.iconAriaLabel}
         time={meta.time}
         isRead={isRead}
-        contextMenuItems={contextMenuItems}
         onOpenContextMenu={
-          onOpenContextMenu
-            ? () => onOpenContextMenu(id, isRead!, meta.type)
-            : undefined
+          onOpenContextMenu ? () => onOpenContextMenu(id) : undefined
         }
         eventName={meta.eventName}
         onRead={() => onRead?.(id, isRead!)}

--- a/src/components/notification/notification_event_meta.test.tsx
+++ b/src/components/notification/notification_event_meta.test.tsx
@@ -107,7 +107,7 @@ describe('EuiNotificationEventMeta', () => {
           type="Alert"
           time={<span>2 min ago</span>}
           iconType="logoCloud"
-          contextMenuItems={contextMenuItems}
+          onOpenContextMenu={() => contextMenuItems}
           eventName="eventName"
         />
       );

--- a/src/components/notification/notification_event_meta.tsx
+++ b/src/components/notification/notification_event_meta.tsx
@@ -17,13 +17,22 @@
  * under the License.
  */
 
-import React, { FunctionComponent, useState, ReactNode } from 'react';
+import React, {
+  FunctionComponent,
+  useState,
+  ReactNode,
+  ReactElement,
+} from 'react';
 import classNames from 'classnames';
 import { EuiIcon, IconType } from '../icon';
 import { EuiBadge, EuiBadgeProps } from '../badge';
 import { EuiPopover } from '../popover';
 import { EuiButtonIcon } from '../button';
-import { EuiContextMenuPanel, EuiContextMenuPanelProps } from '../context_menu';
+import {
+  EuiContextMenuItem,
+  EuiContextMenuItemProps,
+  EuiContextMenuPanel,
+} from '../context_menu';
 import { EuiI18n } from '../i18n';
 import {
   EuiNotificationEventReadButton,
@@ -65,13 +74,11 @@ export type EuiNotificationEventMetaProps = Omit<
    */
   time: ReactNode;
   /**
-   * An array of context menu items. See #EuiContextMenuItem
-   */
-  contextMenuItems?: EuiContextMenuPanelProps['items'];
-  /**
    * Necessary to trigger onOpenContextMenu from EuiNotificationEvent
    */
-  onOpenContextMenu?: () => void;
+  onOpenContextMenu?: () => Array<
+    ReactElement<EuiContextMenuItemProps, typeof EuiContextMenuItem>
+  >;
   /**
    * Applies an `onClick` handler to the `read` indicator.
    */
@@ -89,13 +96,15 @@ export const EuiNotificationEventMeta: FunctionComponent<EuiNotificationEventMet
   eventName,
   iconAriaLabel,
   onOpenContextMenu,
-  contextMenuItems = [],
 }) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const classes = classNames('euiNotificationEventMeta', {
-    'euiNotificationEventMeta--hasContextMenu':
-      onOpenContextMenu || contextMenuItems.length > 0,
+    'euiNotificationEventMeta--hasContextMenu': onOpenContextMenu,
   });
+
+  const [contextMenuItems, setContextMenuItems] = useState<
+    ReturnType<NonNullable<typeof onOpenContextMenu>>
+  >([]);
 
   const id = htmlIdGenerator()();
 
@@ -109,7 +118,9 @@ export const EuiNotificationEventMeta: FunctionComponent<EuiNotificationEventMet
 
   const onOpenPopover = () => {
     setIsPopoverOpen(!isPopoverOpen);
-    onOpenContextMenu?.();
+    if (onOpenContextMenu) {
+      setContextMenuItems(onOpenContextMenu());
+    }
   };
 
   return (
@@ -138,7 +149,7 @@ export const EuiNotificationEventMeta: FunctionComponent<EuiNotificationEventMet
         <span className="euiNotificationEventMeta__time">{time}</span>
       </div>
 
-      {(onOpenContextMenu || contextMenuItems.length > 0) && (
+      {onOpenContextMenu && (
         <div className="euiNotificationEventMeta__contextMenuWrapper">
           <EuiPopover
             id={id}
@@ -169,7 +180,9 @@ export const EuiNotificationEventMeta: FunctionComponent<EuiNotificationEventMet
               </EuiI18n>
             }
             closePopover={() => setIsPopoverOpen(false)}>
-            <EuiContextMenuPanel items={contextMenuItems} />
+            <div onClick={() => setIsPopoverOpen(false)}>
+              <EuiContextMenuPanel items={contextMenuItems} />
+            </div>
           </EuiPopover>
         </div>
       )}


### PR DESCRIPTION
IMO this cleans up the implementation side while adding flexibility. Totally open other opinions, and we should definitely get kibana design / alerting folks into your PR once you feel it's stable enough for that.

Changes:

* Moved the state holding **EuiContextMenuItem**s into *EuiNotificationMeta* which IMO cleans up the implementation code
* Added `div` wrapper around **EuiContextMenu** so it closes after an item is clicked

I also went through how `onClickEventTitle` and `onClickEventPrimaryAction` and passed/called, and I think those are great - so great that's how `onOpenContextMenu` now works 😁