### PR TITLE
Excluding `eventName` at top level and changing title vs aria-label on read button

### DIFF
--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -186,10 +186,10 @@ exports[`EuiNotificationEvent props isRead  is rendered 1`] = `
       class="euiNotificationEventMeta__section"
     >
       <button
-        aria-label="Mark alert-1 as unread."
+        aria-label="Mark title as unread"
         class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
         data-test-subj="notificationEventReadButton"
-        title="Mark alert-1 as unread."
+        title="Mark {eventName} as unread"
         type="button"
       >
         <span
@@ -311,7 +311,7 @@ exports[`EuiNotificationEvent props multiple messages are rendered 1`] = `
           <button
             aria-controls="euiNotificationEventMessagesAccordion_generated-id"
             aria-expanded="false"
-            aria-label="+ 2 messages for alert-1"
+            aria-label="+ 2 messages for title"
             class="euiAccordion__button euiNotificationEventMessages__accordionButton"
             id="generated-id"
             type="button"

--- a/src/components/notification/__snapshots__/notification_event.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`EuiNotificationEvent props isRead  is rendered 1`] = `
         aria-label="Mark title as unread"
         class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
         data-test-subj="notificationEventReadButton"
-        title="Mark {eventName} as unread"
+        title="Mark as unread"
         type="button"
       >
         <span

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`EuiNotificationEventMeta props isRead  is rendered 1`] = `
       aria-label="Mark eventName as unread"
       class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
       data-test-subj="notificationEventReadButton"
-      title="Mark {eventName} as unread"
+      title="Mark as unread"
       type="button"
     >
       <span

--- a/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_meta.test.tsx.snap
@@ -133,10 +133,10 @@ exports[`EuiNotificationEventMeta props isRead  is rendered 1`] = `
     class="euiNotificationEventMeta__section"
   >
     <button
-      aria-label="Mark eventName as unread."
+      aria-label="Mark eventName as unread"
       class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
       data-test-subj="notificationEventReadButton"
-      title="Mark eventName as unread."
+      title="Mark {eventName} as unread"
       type="button"
     >
       <span

--- a/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`EuiNotificationEventReadButton is rendered 1`] = `
   aria-label="Mark eventName as unread"
   class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
   data-test-subj="notificationEventReadButton"
-  title="Mark {eventName} as unread"
+  title="Mark as unread"
   type="button"
 >
   <span

--- a/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
+++ b/src/components/notification/__snapshots__/notification_event_read_button.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`EuiNotificationEventReadButton is rendered 1`] = `
 <button
-  aria-label="Mark eventName as unread."
+  aria-label="Mark eventName as unread"
   class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton euiNotificationEventReadButton--isRead"
   data-test-subj="notificationEventReadButton"
-  title="Mark eventName as unread."
+  title="Mark {eventName} as unread"
   type="button"
 >
   <span
@@ -18,10 +18,10 @@ exports[`EuiNotificationEventReadButton is rendered 1`] = `
 
 exports[`EuiNotificationEventReadButton renders isRead to false 1`] = `
 <button
-  aria-label="Mark eventName as read."
+  aria-label="Mark eventName as read"
   class="euiButtonIcon euiButtonIcon--primary euiNotificationEventReadButton"
   data-test-subj="notificationEventReadButton"
-  title="Mark eventName as read."
+  title="Mark as read"
   type="button"
 >
   <span

--- a/src/components/notification/notification_event.tsx
+++ b/src/components/notification/notification_event.tsx
@@ -46,7 +46,7 @@ export type EuiNotificationHeadingLevel =
 
 export type EuiNotificationEventProps = Omit<
   EuiNotificationEventMetaProps,
-  'isRead' | 'onOpenContextMenu' | 'onRead'
+  'onOpenContextMenu' | 'onRead' | 'eventName'
 > & {
   id: string;
   /**
@@ -61,10 +61,6 @@ export type EuiNotificationEventProps = Omit<
    * Returns the `id` and applies an `onClick` handler to the title.
    */
   onClickTitle?: (id: string) => void;
-  /**
-   * Shows an indicator of the read state of the event.
-   */
-  isRead?: boolean | undefined;
   /**
    * See #EuiNotificationEventPrimaryAction.
    */
@@ -98,7 +94,6 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
   iconAriaLabel,
   time,
   title,
-  eventName,
   isRead,
   primaryAction,
   messages,
@@ -137,7 +132,7 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
         onOpenContextMenu={
           onOpenContextMenu ? () => onOpenContextMenu(id) : undefined
         }
-        eventName={eventName ?? title}
+        eventName={title}
         onRead={() => onRead?.(id, isRead!)}
       />
 
@@ -150,10 +145,7 @@ export const EuiNotificationEvent: FunctionComponent<EuiNotificationEventProps> 
           createElement(headingLevel, titleProps, title)
         )}
 
-        <EuiNotificationEventMessages
-          messages={messages}
-          eventName={eventName ?? title}
-        />
+        <EuiNotificationEventMessages messages={messages} eventName={title} />
 
         {onClickPrimaryAction && primaryAction && (
           <div className="euiNotificationEvent__primaryAction">

--- a/src/components/notification/notification_event_read_button.tsx
+++ b/src/components/notification/notification_event_read_button.tsx
@@ -68,12 +68,12 @@ export const EuiNotificationEventReadButton: FunctionComponent<EuiNotificationEv
 
   const markAsRead = useEuiI18n(
     'euiNotificationEventReadButton.markAsRead',
-    'Mark as read',
+    'Mark as read'
   );
 
   const markAsUnread = useEuiI18n(
     'euiNotificationEventReadButton.markAsUnread',
-    'Mark {eventName} as unread',
+    'Mark as unread'
   );
 
   const buttonAriaLabel = !isRead ? markAsReadAria : markAsUnreadAria;

--- a/src/components/notification/notification_event_read_button.tsx
+++ b/src/components/notification/notification_event_read_button.tsx
@@ -50,29 +50,40 @@ export const EuiNotificationEventReadButton: FunctionComponent<EuiNotificationEv
     'euiNotificationEventReadButton--isRead': isRead,
   });
 
-  const markAsRead = useEuiI18n(
-    'euiNotificationEventReadButton.markAsRead',
-    'Mark {eventName} as read.',
+  const markAsReadAria = useEuiI18n(
+    'euiNotificationEventReadButton.markAsReadAria',
+    'Mark {eventName} as read',
     {
       eventName,
     }
+  );
+
+  const markAsUnreadAria = useEuiI18n(
+    'euiNotificationEventReadButton.markAsUnreadAria',
+    'Mark {eventName} as unread',
+    {
+      eventName,
+    }
+  );
+
+  const markAsRead = useEuiI18n(
+    'euiNotificationEventReadButton.markAsRead',
+    'Mark as read',
   );
 
   const markAsUnread = useEuiI18n(
     'euiNotificationEventReadButton.markAsUnread',
-    'Mark {eventName} as unread.',
-    {
-      eventName,
-    }
+    'Mark {eventName} as unread',
   );
 
-  const buttonLabel = !isRead ? markAsRead : markAsUnread;
+  const buttonAriaLabel = !isRead ? markAsReadAria : markAsUnreadAria;
+  const buttonTitle = !isRead ? markAsRead : markAsUnread;
 
   return (
     <EuiButtonIcon
       iconType="dot"
-      aria-label={buttonLabel}
-      title={buttonLabel}
+      aria-label={buttonAriaLabel}
+      title={buttonTitle}
       className={classesReadState}
       onClick={onClick}
       data-test-subj="notificationEventReadButton"


### PR DESCRIPTION
_This PR will fail the pre-commit hook because I didn't update the docs usages of `eventName`_.

I realized after I pulled the latest changes that the meta props had already been spread at the event level, so that all looks great. All I did really was then omit `eventName` at that top level. I'm trying to understand why a consumer would need or want this over `title` in usages of the aria-labels since the examples are more like id's that mean nothing to the end user.

This was sort of inline with your latest comment on the PR. But if you **do** want to allow customization, now all you have to do is manually add an optional `eventName` prop at the top level in replace of the one that was omitted.