### PR TITLE
Empty prompt guidelines

### DIFF
--- a/src-docs/src/views/empty_prompt/_page_template_table.js
+++ b/src-docs/src/views/empty_prompt/_page_template_table.js
@@ -12,29 +12,31 @@ import {
 export default () => (
   <EuiTable>
     <EuiTableHeader>
-      <EuiTableHeaderCell>Page template</EuiTableHeaderCell>
-      <EuiTableHeaderCell>Empty prompt usage</EuiTableHeaderCell>
+      <EuiTableHeaderCell>
+        EuiPageTemplate <EuiCode>template</EuiCode>
+      </EuiTableHeaderCell>
+      <EuiTableHeaderCell>EuiEmptyPrompt settings</EuiTableHeaderCell>
     </EuiTableHeader>
 
     <EuiTableBody>
       <EuiTableRow>
         <EuiTableRowCell isMobileFullWidth>
-          <EuiCode>{'["centeredContent", "default"]'}</EuiCode>
+          <EuiCode>{"'centeredContent' | 'default'"}</EuiCode>
         </EuiTableRowCell>
 
         <EuiTableRowCell>
-          Set the color to <EuiCode>{'"plain"'}</EuiCode> and the{' '}
-          <EuiCode>hasBorder</EuiCode> prop to <EuiCode>true</EuiCode>.
+          Set <EuiCode language="tsx">{'color="plain"'}</EuiCode> and
+          <EuiCode language="tsx">{'hasBorder={true}'}</EuiCode>.
         </EuiTableRowCell>
       </EuiTableRow>
 
       <EuiTableRow>
         <EuiTableRowCell>
-          <EuiCode>{'["centeredBody", "empty"]'}</EuiCode>
+          <EuiCode>{"'centeredBody' | 'empty'"}</EuiCode>
         </EuiTableRowCell>
 
         <EuiTableRowCell>
-          Set the color to <EuiCode>{'"plain"'}</EuiCode>.
+          Set <EuiCode language="tsx">{'color="plain"'}</EuiCode>.
         </EuiTableRowCell>
       </EuiTableRow>
     </EuiTableBody>

--- a/src-docs/src/views/empty_prompt/custom.js
+++ b/src-docs/src/views/empty_prompt/custom.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import { EuiEmptyPrompt, EuiButton } from '../../../../src/components';
 
@@ -9,12 +9,12 @@ export default () => (
     title={<h2>Start adding cases</h2>}
     titleSize="xs"
     body={
-      <Fragment>
+      <>
         <p>
           There are no cases to display. Add a new case or change your filter
           settings.
         </p>
-      </Fragment>
+      </>
     }
     actions={
       <EuiButton size="s" color="primary" fill>

--- a/src-docs/src/views/empty_prompt/custom.js
+++ b/src-docs/src/views/empty_prompt/custom.js
@@ -11,14 +11,14 @@ export default () => (
     body={
       <Fragment>
         <p>
-          There are no cases to display. Please create a new case or change your
-          filter settings.
+          There are no cases to display. Add a new case or change your filter
+          settings.
         </p>
       </Fragment>
     }
     actions={
       <EuiButton size="s" color="primary" fill>
-        Add new case
+        Add a case
       </EuiButton>
     }
   />

--- a/src-docs/src/views/empty_prompt/empty_prompt.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt.js
@@ -13,13 +13,13 @@ export default () => (
     title={<h2>Start adding cases</h2>}
     body={
       <p>
-        There are no cases to display. Please create a new case or change your
-        filter settings.
+        There are no cases to display. Add a new case or change your filter
+        settings.
       </p>
     }
     actions={
       <EuiButton color="primary" fill>
-        Add new case
+        Add a case
       </EuiButton>
     }
     footer={

--- a/src-docs/src/views/empty_prompt/empty_prompt_error.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_error.js
@@ -5,7 +5,6 @@ import { EuiEmptyPrompt } from '../../../../src/components';
 export default () => (
   <EuiEmptyPrompt
     iconType="alert"
-    iconColor="danger"
     color="danger"
     title={<h2>Error loading Dashboards</h2>}
     body={

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -21,10 +21,11 @@ import PageTemplateTable from './_page_template_table';
 import EmptyPrompt from './empty_prompt';
 const emptyPromptSource = require('!!raw-loader!./empty_prompt');
 const emptyPromptSnippet = `<EuiEmptyPrompt
-  iconType="editorStrike"
+  iconType="logoSolution"
   title={<h2>Your title</h2>}
-  body={bodyContent}
+  body={<p>Content</p>}
   actions={actions}
+  footer={footer}
 />`;
 
 import Layout from './empty_prompt_layout';
@@ -44,7 +45,7 @@ const panelSnippet = `<EuiEmptyPrompt
   iconType="editorStrike"
   color="plain"
   title={<h2>Your title</h2>}
-  body={bodyContent}
+  body={<p>Content</p>}
   actions={actions}
 />`;
 
@@ -54,7 +55,7 @@ const customSnippet = `<EuiEmptyPrompt
   iconType="editorStrike"
   title={<h2>Your title</h2>}
   titleSize="xs"
-  body={bodyContent}
+  body={<p>Content</p>}
   actions={actions}
 />`;
 
@@ -62,7 +63,7 @@ import Simple from './simple';
 const simpleSource = require('!!raw-loader!./simple');
 const simpleSnippet = `<EuiEmptyPrompt
   title={<h2>Your title</h2>}
-  actions={multipleActions}
+  actions={[primaryAction, secondaryAction]}
 />`;
 
 import Loading from './empty_prompt_loading';
@@ -113,29 +114,23 @@ export const EmptyPromptExample = {
           code: emptyPromptSource,
         },
       ],
-      props: { EuiEmptyPrompt },
+      text: (
+        <>
+          <p>
+            While no one piece of content is required, each{' '}
+            <strong>EuiEmptyPrompt</strong> should contain at least a{' '}
+            <EuiCode>title</EuiCode> (wrapped in an HTML heading element) and/or
+            a <EuiCode>description</EuiCode>. They usually contain one or more{' '}
+            <EuiCode>actions</EuiCode> that promotes the primary
+            call-to-actions. You can also provide a <EuiCode>footer</EuiCode> to
+            direct users towards making informed decisions.
+          </p>
+        </>
+      ),
       demo: <EmptyPrompt />,
+      props: { EuiEmptyPrompt },
       snippet: emptyPromptSnippet,
       playground: emptyPromptConfig,
-    },
-    {
-      title: 'Custom sizes and colors',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: customSource,
-        },
-      ],
-      text: (
-        <p>
-          You can control the title size and icon color with the{' '}
-          <EuiCode>titleSize</EuiCode> and <EuiCode>iconColor</EuiCode> props
-          respectively.
-        </p>
-      ),
-      props: { EuiEmptyPrompt },
-      demo: <Custom />,
-      snippet: customSnippet,
     },
     {
       title: 'Less content, more actions',
@@ -158,6 +153,26 @@ export const EmptyPromptExample = {
       demo: <Simple />,
       snippet: simpleSnippet,
     },
+    {
+      title: 'Custom sizes and colors',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: customSource,
+        },
+      ],
+      text: (
+        <p>
+          You can control the title size and icon color with the{' '}
+          <EuiCode>titleSize</EuiCode> and <EuiCode>iconColor</EuiCode> props
+          respectively.
+        </p>
+      ),
+      props: { EuiEmptyPrompt },
+      demo: <Custom />,
+      snippet: customSnippet,
+    },
+
     {
       title: 'Layout',
       source: [

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -33,7 +33,7 @@ const layoutSnippet = `<EuiEmptyPrompt
   layout="horizontal"
   icon={<EuiImage size="fullWidth" src={illustration} alt="" />}
   title={<h2>Your title</h2>}
-  body={bodyContent}
+  body={<p>bodyContent</p>}
   actions={actions}
   footer={footer}
 />`;
@@ -90,6 +90,7 @@ import MultipleTypes from './empty_prompt_multiple_types';
 
 export const EmptyPromptExample = {
   title: 'Empty prompt',
+  guidelines: <Guidelines />,
   intro: (
     <EuiText>
       <p>
@@ -223,36 +224,7 @@ export const EmptyPromptExample = {
       demo: <Panel />,
       snippet: panelSnippet,
     },
-    {
-      title: 'Usage in a page template',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: pageTemplateSource,
-        },
-      ],
-      text: (
-        <>
-          <p>
-            When using a <strong>EuiEmptyPrompt</strong> in a{' '}
-            <Link to="/layout/page">page template</Link>, pay attention to the
-            template you’re passing. The template will determine which{' '}
-            <EuiCode>color</EuiCode> and <EuiCode>hasBorder</EuiCode> prop you
-            should use to ensure consistency across our Elastic products.
-          </p>
-          <PageTemplateTable />
 
-          <EuiSpacer size="xl" />
-          <p>
-            The following example shows the usage of a{' '}
-            <strong>EuiEmptyPrompt</strong> in a page template where the
-            template is set to <EuiCode>{'"empty"'}</EuiCode>.
-          </p>
-        </>
-      ),
-      props: { EuiEmptyPrompt },
-      demo: <PageTemplate />,
-    },
     {
       title: 'Loading and error prompts',
       source: [
@@ -327,15 +299,16 @@ export const EmptyPromptExample = {
       ),
     },
     {
-      title: 'For multiple types of empty states',
+      title: 'More types of empty states',
       wrapText: false,
       text: (
         <>
           <EuiText>
             <p>
-              The following example showcases different types of empty states
-              that you can create with the <strong>EuiEmptyPrompt</strong>. For
-              a full list see the{' '}
+              <strong>EuiEmptyPrompt</strong> can be used for more than just{' '}
+              <strong>empty</strong> pages. The following example showcases
+              different types of empty states that you can create with the{' '}
+              <strong>EuiEmptyPrompt</strong>. For a full list see the{' '}
               <Link to="/guidelines/empty-prompt">usage guidelines</Link>.
             </p>
           </EuiText>
@@ -344,6 +317,35 @@ export const EmptyPromptExample = {
         </>
       ),
     },
+    {
+      title: 'Using in a page template',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: pageTemplateSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            When using a <strong>EuiEmptyPrompt</strong> in a{' '}
+            <Link to="/layout/page">EuiPageTemplate</Link>, pay attention to the
+            template you’re passing. The template will determine which{' '}
+            <EuiCode>color</EuiCode> and <EuiCode>hasBorder</EuiCode> prop you
+            should use to ensure consistency across our Elastic products.
+          </p>
+          <PageTemplateTable />
+
+          <EuiSpacer size="xl" />
+          <p>
+            The following example shows the usage of a{' '}
+            <strong>EuiEmptyPrompt</strong> in a page template where the
+            template is set to <EuiCode>{'"empty"'}</EuiCode>.
+          </p>
+        </>
+      ),
+      props: { EuiEmptyPrompt },
+      demo: <PageTemplate />,
+    },
   ],
-  guidelines: <Guidelines />,
 };

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -49,7 +49,8 @@ import Panel from './empty_prompt_panel_options';
 import Custom from './custom';
 const customSource = require('!!raw-loader!./custom');
 const customSnippet = `<EuiEmptyPrompt
-  iconType="editorStrike"
+  iconType="solutionApp"
+  iconColor="default"
   title={<h2>Your title</h2>}
   titleSize="xs"
   body={<p>Content</p>}
@@ -172,9 +173,8 @@ export const EmptyPromptExample = {
         </>
       ),
     },
-
     {
-      title: 'Custom sizes and colors',
+      title: 'Title sizes and icon colors',
       source: [
         {
           type: GuideSectionTypes.JS,
@@ -183,9 +183,15 @@ export const EmptyPromptExample = {
       ],
       text: (
         <p>
-          You can control the title size and icon color with the{' '}
-          <EuiCode>titleSize</EuiCode> and <EuiCode>iconColor</EuiCode> props
-          respectively.
+          Other customization options include changing the
+          <EuiCode>titleSize</EuiCode> to any of the{' '}
+          <Link to="/display/title">
+            <strong>EuiTitle</strong> sizes
+          </Link>{' '}
+          and <EuiCode>iconColor</EuiCode>. When using an application or
+          solution logo as the <EuiCode>iconType</EuiCode>, you can reset to the
+          multi-tone colors with{' '}
+          <EuiCode language="tsx">{'iconColor="default"'}</EuiCode>
         </p>
       ),
       props: { EuiEmptyPrompt },

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -10,8 +10,6 @@ import {
   EuiSpacer,
 } from '../../../../src/components';
 
-import { COLORS } from '../../../../src/components/panel/panel';
-
 import Guidelines from './guidelines';
 
 import emptyPromptConfig from './playground';
@@ -39,15 +37,14 @@ const layoutSnippet = `<EuiEmptyPrompt
   footer={footer}
 />`;
 
-import Panel from './empty_prompt_panel';
-const panelSource = require('!!raw-loader!./empty_prompt_panel');
-const panelSnippet = `<EuiEmptyPrompt
-  iconType="editorStrike"
-  color="plain"
+import Simple from './simple';
+const simpleSource = require('!!raw-loader!./simple');
+const simpleSnippet = `<EuiEmptyPrompt
   title={<h2>Your title</h2>}
-  body={<p>Content</p>}
-  actions={actions}
+  actions={[primaryAction, secondaryAction]}
 />`;
+
+import Panel from './empty_prompt_panel_options';
 
 import Custom from './custom';
 const customSource = require('!!raw-loader!./custom');
@@ -57,13 +54,6 @@ const customSnippet = `<EuiEmptyPrompt
   titleSize="xs"
   body={<p>Content</p>}
   actions={actions}
-/>`;
-
-import Simple from './simple';
-const simpleSource = require('!!raw-loader!./simple');
-const simpleSnippet = `<EuiEmptyPrompt
-  title={<h2>Your title</h2>}
-  actions={[primaryAction, secondaryAction]}
 />`;
 
 import Loading from './empty_prompt_loading';
@@ -154,6 +144,36 @@ export const EmptyPromptExample = {
       snippet: simpleSnippet,
     },
     {
+      title: 'Panel options',
+      wrapText: false,
+      text: (
+        <>
+          <EuiText>
+            <p>
+              The <strong>EuiEmptyPrompt</strong> is wrapped by{' '}
+              <Link to="/layout/panel">
+                <strong>EuiPanel</strong>
+              </Link>
+              . By default, the panel is set to <EuiCode>transparent</EuiCode>{' '}
+              but you can customize other panel options like{' '}
+              <EuiCode>color</EuiCode>, <EuiCode>hasBorder</EuiCode> and{' '}
+              <EuiCode>paddingSize</EuiCode>. Changing the{' '}
+              <EuiCode>color</EuiCode> prop will also attempt to adjust the{' '}
+              <EuiCode>iconColor</EuiCode> and <EuiCode>footer</EuiCode> color.
+            </p>
+            <p>
+              Read the{' '}
+              <Link to="/guidelines/empty-prompt">usage guidelines</Link> to
+              better understand when to use certain panel props.
+            </p>
+          </EuiText>
+          <EuiSpacer />
+          <Panel />
+        </>
+      ),
+    },
+
+    {
       title: 'Custom sizes and colors',
       source: [
         {
@@ -207,36 +227,6 @@ export const EmptyPromptExample = {
       props: { EuiEmptyPrompt },
       demo: <Layout />,
       snippet: layoutSnippet,
-    },
-    {
-      title: 'Panel colors',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: panelSource,
-        },
-      ],
-      text: (
-        <>
-          <p>
-            The <strong>EuiEmptyPrompt</strong> is built on top of{' '}
-            <Link to="/layout/panel">
-              <strong>EuiPanel</strong>
-            </Link>
-            . By default, the panel color is set to transparent but you can
-            customize the panel color by passing one of the color options:{' '}
-            <EuiCode language="js">{JSON.stringify(COLORS, null, 2)}</EuiCode>.
-          </p>
-          <p>
-            Read the <Link to="/guidelines/empty-prompt">usage guidelines</Link>{' '}
-            to understand better what scenarios you should stick to the
-            transparent color or use any other colors.
-          </p>
-        </>
-      ),
-      props: { EuiEmptyPrompt },
-      demo: <Panel />,
-      snippet: panelSnippet,
     },
 
     {

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -198,43 +198,6 @@ export const EmptyPromptExample = {
       demo: <Custom />,
       snippet: customSnippet,
     },
-
-    {
-      title: 'Layout',
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: layoutSource,
-        },
-      ],
-      text: (
-        <>
-          <p>
-            You can supply a layout of either <EuiCode>horizontal</EuiCode> or{' '}
-            <EuiCode>vertical</EuiCode> with the default being{' '}
-            <EuiCode>vertical</EuiCode>. When creating empty states we want the
-            content to be short and straight to the point. So most of the time,
-            the <EuiCode>vertical</EuiCode> layout is enough. All the content
-            will be center aligned and this type of text alignment only works
-            with small content.
-          </p>
-          <p>
-            When you have longer texts or multiple calls to action, you can use
-            the <EuiCode>horizontal</EuiCode> layout. However, this layout only
-            works when you can provide an illustration. For consistency, we
-            recommend using the illustration with a{' '}
-            <Link to="/display/image">
-              <strong>EuiImage</strong>
-            </Link>{' '}
-            with the size set to <EuiCode>{'"fullWidth"'}</EuiCode>.
-          </p>
-        </>
-      ),
-      props: { EuiEmptyPrompt },
-      demo: <Layout />,
-      snippet: layoutSnippet,
-    },
-
     {
       title: 'Loading and error prompts',
       source: [
@@ -307,6 +270,47 @@ export const EmptyPromptExample = {
           <States />
         </div>
       ),
+    },
+    {
+      title: 'Layout',
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: layoutSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            You can supply a <EuiCode>layout</EuiCode> of either{' '}
+            <EuiCode>{'"horizontal"'}</EuiCode> or{' '}
+            <EuiCode>{'"vertical"'}</EuiCode> with the default being{' '}
+            <EuiCode>{'vertical'}</EuiCode>. When creating empty states we want
+            the content to be short and straight to the point. So most of the
+            time, the <EuiCode>vertical</EuiCode> layout is enough. All the
+            content will be center aligned and this type of text alignment only
+            works with small content.
+          </p>
+          <p>
+            When you have longer body text with multiple calls to action, you
+            can use the <EuiCode>horizontal</EuiCode> layout. This layout works
+            best when you can provide a larger graphic like an illustration as
+            the <EuiCode>icon</EuiCode>. For consistency, we recommend providing
+            the illustration using a{' '}
+            <Link to="/display/image">
+              <strong>EuiImage</strong>
+            </Link>{' '}
+            with <EuiCode language="tsx">{'size="fullWidth"'}</EuiCode>.
+          </p>
+        </>
+      ),
+      props: { EuiEmptyPrompt },
+      demo: <Layout />,
+      demoPanelProps: {
+        color: 'subdued',
+        paddingSize: 'l',
+      },
+      snippet: layoutSnippet,
     },
     {
       title: 'More types of empty states',

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -76,7 +76,6 @@ import Error from './empty_prompt_error';
 const errorSource = require('!!raw-loader!./empty_prompt_error');
 const errorSnippet = `<EuiEmptyPrompt
   iconType="alert"
-  iconColor="danger"
   title={<h2>There was an error</h2>}
 />`;
 

--- a/src-docs/src/views/empty_prompt/empty_prompt_example.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_example.js
@@ -67,6 +67,7 @@ const loadingSnippet = `<EuiEmptyPrompt
 import Error from './empty_prompt_error';
 const errorSource = require('!!raw-loader!./empty_prompt_error');
 const errorSnippet = `<EuiEmptyPrompt
+  color="danger"
   iconType="alert"
   title={<h2>There was an error</h2>}
 />`;
@@ -213,9 +214,9 @@ export const EmptyPromptExample = {
             by utilizing the same patterns.
           </p>
           <p>
-            For <strong>loading</strong> states, you can simply replace the{' '}
-            <EuiCode>iconType</EuiCode> with a custom <EuiCode>icon</EuiCode> by
-            passing in one of our{' '}
+            For <strong>loading</strong> states, instead of passing a{' '}
+            <EuiCode>iconType</EuiCode>, you can provide a custom{' '}
+            <EuiCode>icon</EuiCode> and pass in one of our{' '}
             <Link to="/display/loading">loading components</Link>.
           </p>
         </>
@@ -235,41 +236,13 @@ export const EmptyPromptExample = {
         <>
           <p>
             For <strong>error</strong> states, you can simply set the{' '}
-            <EuiCode>iconColor</EuiCode> to <EuiCode>danger</EuiCode> and/or
-            pass <EuiCode>danger</EuiCode> to the <EuiCode>color</EuiCode> prop.
+            <EuiCode>color</EuiCode> to <EuiCode>danger</EuiCode>.
           </p>
         </>
       ),
       props: { EuiEmptyPrompt },
       demo: <Error />,
       snippet: errorSnippet,
-    },
-    {
-      source: [
-        {
-          type: GuideSectionTypes.JS,
-          code: statesSource,
-        },
-      ],
-      text: (
-        <>
-          <p>
-            You can then tie all three states together to create a seamless
-            loading to empty or loading to error experience. The following
-            example shows how to encorprate these states with{' '}
-            <Link to="/layout/page#simple-layout-with-centered-content">
-              <strong>EuiPageTemplate</strong>
-            </Link>{' '}
-            using <EuiCode>{'template="centeredContent"'}</EuiCode>.
-          </p>
-        </>
-      ),
-      props: { EuiEmptyPrompt },
-      demo: (
-        <div className="guideDemo__highlightLayout">
-          <States />
-        </div>
-      ),
     },
     {
       title: 'Layout',
@@ -360,6 +333,33 @@ export const EmptyPromptExample = {
       ),
       props: { EuiEmptyPrompt },
       demo: <PageTemplate />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: statesSource,
+        },
+      ],
+      text: (
+        <>
+          <p>
+            You can then tie multiple types of empty states together to create a
+            seamless loading to empty or loading to error experience. The
+            following example shows how to encorprate these states with{' '}
+            <Link to="/layout/page#simple-layout-with-centered-content">
+              <strong>EuiPageTemplate</strong>
+            </Link>{' '}
+            using <EuiCode>{'template="centeredContent"'}</EuiCode>.
+          </p>
+        </>
+      ),
+      props: { EuiEmptyPrompt },
+      demo: (
+        <div className="guideDemo__highlightLayout">
+          <States />
+        </div>
+      ),
     },
   ],
 };

--- a/src-docs/src/views/empty_prompt/empty_prompt_multiple_types.tsx
+++ b/src-docs/src/views/empty_prompt/empty_prompt_multiple_types.tsx
@@ -25,7 +25,7 @@ export default () => {
   }> = [
     {
       value: 'pageError',
-      text: 'Page error',
+      text: 'Page not found',
       component: pageError,
       source: pageErrorSource,
     },

--- a/src-docs/src/views/empty_prompt/empty_prompt_panel.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_panel.js
@@ -1,77 +1,39 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   EuiEmptyPrompt,
   EuiButton,
-  EuiSpacer,
-  EuiSelect,
   EuiTitle,
   EuiLink,
 } from '../../../../src/components';
 
-export default () => {
-  const panelColorsArray = [
-    'plain',
-    'primary',
-    'success',
-    'accent',
-    'warning',
-    'danger',
-    'subdued',
-    'transparent',
-  ];
-
-  const panelColorsOptions = panelColorsArray.map((name) => {
-    return {
-      value: name,
-      text: name,
-    };
-  });
-
-  const [panelColor, setPanelColor] = useState(panelColorsOptions[0].value);
-
-  const onChangePanelColor = (e) => {
-    setPanelColor(e.target.value);
-  };
-
+export default ({ color }) => {
   return (
-    <>
-      <EuiSelect
-        prepend="Color"
-        options={panelColorsOptions}
-        value={panelColor}
-        onChange={(e) => onChangePanelColor(e)}
-        compressed
-        aria-label="Empty prompt panel colors"
-      />
-
-      <EuiSpacer size="l" />
-      <EuiEmptyPrompt
-        iconType="logoSecurity"
-        title={<h2>Start adding cases</h2>}
-        color={panelColor}
-        body={
-          <p>
-            There are no cases to display. Add a new case or change your filter
-            settings.
-          </p>
-        }
-        actions={
-          <EuiButton color="primary" fill>
-            Add a case
-          </EuiButton>
-        }
-        footer={
-          <>
-            <EuiTitle size="xxs">
-              <h3>Want to learn more?</h3>
-            </EuiTitle>
-            <EuiLink href="#" target="_blank">
-              Read documentation
-            </EuiLink>
-          </>
-        }
-      />
-    </>
+    <EuiEmptyPrompt
+      iconType="securityAnalyticsApp"
+      title={<h2>Start adding cases</h2>}
+      color={color}
+      body={
+        <p>
+          There are no cases to display. Add a new case or change your filter
+          settings.
+        </p>
+      }
+      actions={
+        <EuiButton color="primary" fill>
+          Add a case
+        </EuiButton>
+      }
+      footer={
+        <>
+          <EuiTitle size="xxs">
+            <h3>Want to learn more?</h3>
+          </EuiTitle>
+          <EuiLink href="#" target="_blank">
+            Read documentation
+          </EuiLink>
+        </>
+      }
+    />
   );
 };

--- a/src-docs/src/views/empty_prompt/empty_prompt_panel.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_panel.js
@@ -52,13 +52,13 @@ export default () => {
         color={panelColor}
         body={
           <p>
-            There are no cases to display. Please create a new case or change
-            your filter settings.
+            There are no cases to display. Add a new case or change your filter
+            settings.
           </p>
         }
         actions={
           <EuiButton color="primary" fill>
-            Add new case
+            Add a case
           </EuiButton>
         }
         footer={

--- a/src-docs/src/views/empty_prompt/empty_prompt_panel_options.tsx
+++ b/src-docs/src/views/empty_prompt/empty_prompt_panel_options.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable import/no-unresolved */
+import React, { useState } from 'react';
+
+import {
+  EuiSpacer,
+  EuiSelect,
+  EuiEmptyPrompt,
+} from '../../../../src/components';
+import { GuideSection } from '../../components/guide_section/guide_section';
+import { GuideSectionTypes } from '../../components/guide_section/guide_section_types';
+import { COLORS, PanelColor } from '../../../../src/components/panel/panel';
+
+// @ts-ignore Importing from JS
+import Panel from './empty_prompt_panel';
+const panelSource = require('!!raw-loader!./empty_prompt_panel');
+
+export default () => {
+  const panelColorsOptions = COLORS.map((name) => {
+    return {
+      value: name,
+      text: name,
+    };
+  });
+
+  const [panelColor, setPanelColor] = useState(panelColorsOptions[0].value);
+
+  const onChangePanelColor = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setPanelColor(e.target.value as PanelColor);
+  };
+
+  return (
+    <>
+      <EuiSelect
+        prepend="Color"
+        options={panelColorsOptions}
+        value={panelColor}
+        onChange={(e) => onChangePanelColor(e)}
+        compressed
+        aria-label="Empty prompt panel colors"
+      />
+
+      <EuiSpacer size="l" />
+
+      <GuideSection
+        demo={<Panel color={panelColor} />}
+        source={[
+          {
+            type: GuideSectionTypes.JS,
+            code: panelSource,
+          },
+        ]}
+        props={{ EuiEmptyPrompt }}
+        snippet={`<EuiEmptyPrompt
+  iconType="solutionApp"
+  color="${panelColor}"
+  title={<h2>Your title</h2>}
+  body={<p>Content</p>}
+  actions={actions}
+  footer={footer}
+/>`}
+      />
+    </>
+  );
+};

--- a/src-docs/src/views/empty_prompt/empty_prompt_states.js
+++ b/src-docs/src/views/empty_prompt/empty_prompt_states.js
@@ -30,7 +30,6 @@ export default () => {
       emptyPromptProps = {
         color: 'danger',
         iconType: 'alert',
-        iconColor: 'danger',
         title: <h2>Error loading Dashboards</h2>,
         body: (
           <p>

--- a/src-docs/src/views/empty_prompt/playground.js
+++ b/src-docs/src/views/empty_prompt/playground.js
@@ -28,6 +28,7 @@ export default () => {
   propsToUse.iconColor = {
     ...propsToUse.iconColor,
     type: PropTypes.Enum,
+    defaultValue: 'subdued',
     options: ICON_COLORS.reduce((a, v) => ({ ...a, [v]: v }), {}),
   };
 

--- a/src-docs/src/views/empty_prompt/playground.js
+++ b/src-docs/src/views/empty_prompt/playground.js
@@ -5,7 +5,8 @@ import {
   EuiTitle,
   EuiText,
   EuiLink,
-} from '../../../../src/components/';
+  ICON_COLORS,
+} from '../../../../src/components';
 import {
   propUtilityForPlayground,
   iconValidator,
@@ -23,41 +24,42 @@ export default () => {
     type: PropTypes.ReactNode,
   };
 
+  propsToUse.iconType = iconValidator(propsToUse.iconType, 'logoSecurity');
   propsToUse.iconColor = {
     ...propsToUse.iconColor,
     type: PropTypes.Enum,
-    defaultValue: 'subdued',
-    options: {
-      default: 'default',
-      subdued: 'subdued',
-      success: 'success',
-      accent: 'accent',
-      danger: 'danger',
-      warning: 'warning',
-      ghost: 'ghost',
-    },
+    options: ICON_COLORS.reduce((a, v) => ({ ...a, [v]: v }), {}),
   };
 
   propsToUse.actions.type = PropTypes.String;
 
-  propsToUse.body.type = PropTypes.String;
-  propsToUse.body.value =
-    'There are no cases to display. Please create a new case or change your filter settings.';
+  propsToUse.body = {
+    ...propsToUse.body,
+    value:
+      '<p>There are no cases to display. Please create a new case or change your filter settings.</p>',
+    type: PropTypes.ReactNode,
+  };
+
+  propsToUse.actions = {
+    ...propsToUse.actions,
+    value: `<EuiButton color="primary" fill>
+  Add new case
+</EuiButton>`,
+    type: PropTypes.ReactNode,
+  };
 
   propsToUse.footer = {
     ...propsToUse.footer,
     value: `<>
-    <EuiTitle size="xxs">
-      <h3>Want to learn more?</h3>
-    </EuiTitle>
-    <EuiLink href="#" target="_blank">
-      Read documentation
-    </EuiLink>
-  </>`,
+  <EuiTitle size="xxs">
+    <h3>Want to learn more?</h3>
+  </EuiTitle>
+  <EuiLink href="#" target="_blank">
+    Read documentation
+  </EuiLink>
+</>`,
     type: PropTypes.ReactNode,
   };
-
-  propsToUse.iconType = iconValidator(propsToUse.iconType, 'logoSecurity');
 
   return {
     config: {

--- a/src-docs/src/views/empty_prompt/playground.js
+++ b/src-docs/src/views/empty_prompt/playground.js
@@ -36,14 +36,14 @@ export default () => {
   propsToUse.body = {
     ...propsToUse.body,
     value:
-      '<p>There are no cases to display. Please create a new case or change your filter settings.</p>',
+      '<p>There are no cases to display. Add a new case or change your filter settings.</p>',
     type: PropTypes.ReactNode,
   };
 
   propsToUse.actions = {
     ...propsToUse.actions,
     value: `<EuiButton color="primary" fill>
-  Add new case
+  Add a case
 </EuiButton>`,
     type: PropTypes.ReactNode,
   };

--- a/src-docs/src/views/empty_prompt/prompt_types/no_permission.tsx
+++ b/src-docs/src/views/empty_prompt/prompt_types/no_permission.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 
-import { EuiEmptyPrompt, EuiButton } from '../../../../../src/components';
+import { EuiEmptyPrompt } from '../../../../../src/components';
 
 export default () => (
   <EuiEmptyPrompt
     iconType="lock"
+    color="subdued"
     title={<h2>Contact your administrator for access</h2>}
     body={<p>To view cases in this space, you need additional privileges.</p>}
-    actions={
-      <EuiButton color="primary" fill>
-        Go home
-      </EuiButton>
-    }
   />
 );

--- a/src/components/empty_prompt/empty_prompt.tsx
+++ b/src/components/empty_prompt/empty_prompt.tsx
@@ -14,6 +14,7 @@ import { EuiTitle, EuiTitleSize } from '../title';
 import { EuiFlexGroup, EuiFlexItem } from '../flex';
 import { EuiSpacer } from '../spacer';
 import { EuiIcon, IconColor, IconType } from '../icon';
+import { COLORS as ICON_COLORS } from '../icon/icon';
 import { EuiText, EuiTextColor } from '../text';
 import { EuiPanel, _EuiPanelDivlike } from '../panel/panel';
 
@@ -34,7 +35,7 @@ export type EuiEmptyPromptProps = CommonProps &
     'borderRadius' | 'grow' | 'panelRef' | 'paddingSize' | 'title'
   > & {
     /*
-     * Accepts any `EuiIcon.type` or pass a custom node
+     * Accepts any [EuiIcon.type](#/display/icons)
      */
     iconType?: IconType;
     /**
@@ -82,7 +83,7 @@ export type EuiEmptyPromptProps = CommonProps &
 export const EuiEmptyPrompt: FunctionComponent<EuiEmptyPromptProps> = ({
   icon,
   iconType,
-  iconColor = 'subdued',
+  iconColor: _iconColor,
   title,
   titleSize = 'm',
   paddingSize = 'l',
@@ -96,6 +97,10 @@ export const EuiEmptyPrompt: FunctionComponent<EuiEmptyPromptProps> = ({
   ...rest
 }) => {
   const isVerticalLayout = layout === 'vertical';
+  // Default the iconColor to `subdued`,
+  // otherwise try to match the iconColor with the panel color unless iconColor is specified
+  const iconColor =
+    _iconColor ?? (ICON_COLORS.includes(color as any) ? color : 'subdued');
 
   const iconNode = iconType ? (
     <EuiIcon type={iconType} size="xxl" color={iconColor} />


### PR DESCRIPTION
Here's a PR @miukimiu where I mostly just organized/edited the examples a bit. You can read the commit descriptions to see what I did.

The one change I did end up making to the component itself was to try to align the panel `color` with the `iconColor`. Like if the consumer passes `color="danger"` it will also apply `danger` as the `iconColor` (unless the consumer specifically overrides this with a custom `iconColor`).

I'll take a quick peak at the Guidelines on friday. They mostly look good to me, probably just some grammar adjusting.