### PR TITLE
Allowing for `children` and utilizing `body` over `header`

### DIFF
--- a/src-docs/src/views/timeline/timeline.tsx
+++ b/src-docs/src/views/timeline/timeline.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import {
   EuiTimeline,
+  EuiTimelineItem,
   EuiTimelineProps,
   EuiText,
+  EuiAvatar,
+  EuiStepNumber,
+  EuiHorizontalRule,
 } from '../../../../src/components';
 
 const items: EuiTimelineProps['items'] = [
   {
     icon: 'email',
-    header: (
+    body: (
       <EuiText size="s">
         <p>
           <strong>janet@elastic.co</strong> was invited to the project
@@ -18,7 +22,7 @@ const items: EuiTimelineProps['items'] = [
   },
   {
     icon: 'pencil',
-    header: (
+    body: (
       <EuiText size="s">
         <p>
           The project was renamed to <strong>Revenue Dashboard</strong>
@@ -28,7 +32,7 @@ const items: EuiTimelineProps['items'] = [
   },
   {
     icon: 'folderClosed',
-    header: (
+    body: (
       <EuiText size="s">
         <p>The project was archived</p>
       </EuiText>
@@ -36,4 +40,36 @@ const items: EuiTimelineProps['items'] = [
   },
 ];
 
-export default () => <EuiTimeline items={items} />;
+export default () => (
+  <>
+    <EuiTimeline items={items} />
+
+    <EuiHorizontalRule />
+
+    <EuiTimeline>
+      <EuiTimelineItem icon="email">
+        <EuiText size="s">
+          <p>
+            <strong>janet@elastic.co</strong> was invited to the project
+          </p>
+        </EuiText>
+      </EuiTimelineItem>
+      <EuiTimelineItem
+        icon={<EuiAvatar name="Username" />}
+        panelProps={{ color: 'danger' }}
+      >
+        <EuiText size="s">
+          <p>The project was archived</p>
+        </EuiText>
+      </EuiTimelineItem>
+      <EuiTimelineItem icon={<EuiStepNumber number={3} />}>
+        <EuiText size="s">
+          <h3>Step 3</h3>
+          <p>
+            The project was renamed to <strong>Revenue Dashboard</strong>
+          </p>
+        </EuiText>
+      </EuiTimelineItem>
+    </EuiTimeline>
+  </>
+);

--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -21,6 +21,7 @@ export type EuiTimelineProps = HTMLAttributes<HTMLDivElement> &
 
 export const EuiTimeline: FunctionComponent<EuiTimelineProps> = ({
   className,
+  children,
   items,
   ...rest
 }) => {
@@ -36,7 +37,7 @@ export const EuiTimeline: FunctionComponent<EuiTimelineProps> = ({
 
   return (
     <div className={classes} {...rest}>
-      {timelineElements}
+      {timelineElements || children}
     </div>
   );
 };

--- a/src/components/timeline/timeline_item_event.tsx
+++ b/src/components/timeline/timeline_item_event.tsx
@@ -70,6 +70,7 @@ export const EuiTimelineItemEvent: FunctionComponent<EuiTimelineItemEventProps> 
   className,
   header,
   body,
+  children,
   panelProps = {
     paddingSize: 'none',
     color: 'transparent',
@@ -110,7 +111,7 @@ export const EuiTimelineItemEvent: FunctionComponent<EuiTimelineItemEventProps> 
           <HeaderElement className={headerClasses}>{header}</HeaderElement>
         )}
 
-        {body && <div className={bodyClasses}>{body}</div>}
+        {children || (body && <div className={bodyClasses}>{body}</div>)}
       </Element>
     </EuiPanel>
   );


### PR DESCRIPTION
@miukimiu 

I dug around a bit in what you have (and outside of adjusting any styles) this is how I'd like to be able to write this component. Instead of relying solely on a prop like `body` to render the timeline contents, just use the typical `children` prop. Then in terms of fixing up spacing I'd prioritize requiring `children` instead of `header.

I updated only the first docs example you had to showcase what I mean. I left in your `items` prop which can still be a useful way of providing the data, but also allowing for using the `<EuiTimelineEvent>` component directly so as to be able to write in the `children` nicely (more like typical HTML).

I realized it didn't need to go so far as the `EuiSplitPanel.Outer/.Inner` does, so I think just `<EuiTimeline>` and `<EuiTimelineEvent>` is fine here. 

There's still an argument whether `header` is necessary here since I still think it's just `children` content, but we can evaluate later.